### PR TITLE
Added --retry to tail

### DIFF
--- a/ark-server.sh
+++ b/ark-server.sh
@@ -5,7 +5,7 @@ steamcmd +login anonymous +app_update 2430930 validate +quit
 
 # Start server with proton
 SERVER_CMD="$PROTON run \"${ARK_PATH}/Binaries/Win64/ArkAscendedServer.exe\" \
-  \"TheIsland_WP?listen?SessionName=${SESSION_NAME}?ServerAdminPassword=${ADMIN_PASSWORD}?Port=${GAME_PORT}?QueryPort=${QUERY_PORT}?MaxPlayers=${MAX_PLAYERS}?\""
+  \"TheIsland_WP?listen?SessionName=\\\"${SESSION_NAME}\\\"?ServerAdminPassword=\\\"${ADMIN_PASSWORD}\\\"?Port=${GAME_PORT}?QueryPort=${QUERY_PORT}?MaxPlayers=${MAX_PLAYERS}?\""
 
 # Install mods
 if [ -n "$MODS" ]; then

--- a/ark-server.sh
+++ b/ark-server.sh
@@ -22,7 +22,7 @@ eval $SERVER_CMD > /dev/null 2>&1 &
 SERVER_PID=$!
 
 # Capture logs
-tail -f "${ARK_PATH}/Saved/Logs/ShooterGame.log" &
+tail -f --retry "${ARK_PATH}/Saved/Logs/ShooterGame.log" &
 
 # Monitor server process
 wait $SERVER_PID


### PR DESCRIPTION
tail command failed when the ShooterGame.log file did not exist. To avoid the command failing --retry was added.